### PR TITLE
black button의 fill option이 없을 때 기본 color를 white로 명시

### DIFF
--- a/src/components/Button/BaseButton/Button.styles.js
+++ b/src/components/Button/BaseButton/Button.styles.js
@@ -97,7 +97,8 @@ export const Container = styled.div`
 export const BlackButton = styled(Container)`
   border-color: ${gray100};
   color: ${gray450};
-      
+  background-color: ${white};
+
   ${({ fillColor }) =>
     fillColor &&
     css`
@@ -113,7 +114,7 @@ export const BlackButton = styled(Container)`
         background-color: ${gray50};
       }
     `}
-  
+
   ${({ fillColor, large }) =>
     fillColor &&
     large &&


### PR DESCRIPTION
black button의 fill option이 없을 때 기본 color를 white로 명시했습니다.

gatsby나 docz를 build하는 법을 몰라 PR만 달아두었습니다.

확인 부탁드립니다 ㅎㅎ