### PR TITLE
feature: Rollup config file added for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 yarn-error.log
 .docz
+.env

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:dev": "rollup -c rollup.config.dev.js -w",
     "build:all": "yarn build && yarn docz:build",
     "docz:dev": "docz dev",
     "docz:build": "rm -rf ./docs .docz/.cache && docz build",
@@ -50,6 +51,7 @@
   "dependencies": {
     "@tippy.js/react": "^3.1.1",
     "body-scroll-lock": "^3.0.2",
+    "dotenv": "^8.2.0",
     "react-modal": "^3.11.2",
     "react-outside-click-handler": "^1.3.0",
     "react-text-mask": "^5.4.3",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,0 +1,58 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from 'rollup-plugin-babel';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import image from '@rollup/plugin-image';
+import postcss from 'rollup-plugin-postcss';
+import { terser } from 'rollup-plugin-terser';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+process.env.BABEL_ENV = 'production';
+
+const outputData = [
+  {
+    file: `${process.env.DIRECTORY}/dist/index.js`,
+    format: 'es',
+  },
+  {
+    file: `${process.env.DIRECTORY}/dist/index.cjm.js`,
+    format: 'cjs',
+  },
+];
+
+const plugins = [
+  peerDepsExternal(),
+  image(),
+  postcss(),
+  babel({
+    exclude: 'node_modules/**',
+    runtimeHelpers: true,
+  }),
+  commonjs(),
+  resolve(),
+  terser(),
+];
+
+/**
+ * External Dependencies
+ */
+const dependencies = [
+  '@tippy.js/react',
+  'react-toastify',
+  'react-outside-click-handler',
+  'react-text-mask',
+  'body-scroll-lock',
+  'react-modal',
+];
+
+export default outputData.map(({ file, format }) => ({
+  input: 'src/index.js',
+  plugins,
+  output: {
+    file: file,
+    format: format,
+  },
+  external: dependencies,
+}));


### PR DESCRIPTION
## Rollup Dev Config

Rollup Configuration file을 새롭게 제작하였습니다.

이제 `yarn build:dev` 를 실행하면 원하는 프로젝트에 publish없이 바로바로 remember-ui 개발사항이 반영될 수 있도록 수정하였습니다.

전제조건으로, 프로젝트 루트 디렉토리에 `.env` 파일을 생성해줘야 합니다.

이후, 해당 `.env` 파일 안에 아래와 같이 원하는 디렉토리 명을 적어주면 됩니다. (~과 같은 디렉토리는 사용할 수 없습니다.)

```
DIRECTORY=../career-web/node_modules/remember-ui
```

.env 파일은 개발자별로 프로젝트가 다를 수 있기 때문에 gitignore 처리하였습니다. 개별적으로 생성하신 후 커밋은 하지 말아주시기 바랍니다.

기본적으로 watch 옵션이 들어갔기 때문에, 켜놓고 사용하면 변경사항을 저장할 때마다 파일을 새롭게 생성합니다. (평균적으로 저장을 누르면 약 1~2초 정도 시간이 발생합니다)
