### PR TITLE
PCWEB-4375 IE에서 비활성화된 Select 옵션에서 스크롤 안되는 문제 해결

### DIFF
--- a/src/components/Control/Select/Select.styles.js
+++ b/src/components/Control/Select/Select.styles.js
@@ -127,8 +127,8 @@ export const OptionItem = styled.div`
     `}
   ${({ custom }) =>
     custom && font({ size: '15px', weight: 'bold', color: yellow100 })}
-  ${({ disabled }) =>
-    disabled &&
+  ${({ disable }) =>
+    disable &&
     css`
       cursor: default;
       opacity: 0.3;

--- a/src/components/Control/Select/index.js
+++ b/src/components/Control/Select/index.js
@@ -69,7 +69,7 @@ export const Select = ({
                     key={`option-${index}`}
                     custom={id === 'custom'}
                     selected={value === id}
-                    disabled={disabled}
+                    disable={disabled}
                     onClick={() => {
                       if (!disabled) {
                         id !== 'custom' ? onChange(id) : changeInputMode();


### PR DESCRIPTION
## 작업 내용 (Content)
IE에서는 disabled 속성이 있는 항목에서는 스크롤이 안됩니다.
이로인해 ie에서 제안 포지션을 선택할때 스크롤을 못하는 문제가 있었습니다.
Select Option의 disabled 속성은 투명도 조절에만 쓰여서 disabled 대신 disable로 속성명을 바꿨습니다

## 링크 (Links)

- [JIRA (IE Only) 포지션 선택 dropbox 스크롤시 스크롤이 작동하지 않음](http://jira.dramancompany.com/browse/PCWEB-4375)

## 기타 사항 (Etc)


## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)

2020.8.8. Fri
