### PR TITLE
NewBaseButton과 Custombottom의 내부 text 가운데 정렬 시각 보정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remember-ui",
-  "version": "1.11.0-beta.2",
+  "version": "1.10.0",
   "description": "Remember UI Components",
   "homepage": "https://github.com/dramancompany/remember-ui",
   "author": "DramanCompany",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remember-ui",
-  "version": "1.10.0",
+  "version": "1.11.0-beta.0",
   "description": "Remember UI Components",
   "homepage": "https://github.com/dramancompany/remember-ui",
   "author": "DramanCompany",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remember-ui",
-  "version": "1.11.0-beta.0",
+  "version": "1.11.0-beta.1",
   "description": "Remember UI Components",
   "homepage": "https://github.com/dramancompany/remember-ui",
   "author": "DramanCompany",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remember-ui",
-  "version": "1.11.0-beta.1",
+  "version": "1.11.0-beta.2",
   "description": "Remember UI Components",
   "homepage": "https://github.com/dramancompany/remember-ui",
   "author": "DramanCompany",

--- a/src/components/Button/CustomButton/CustomButton.styles.js
+++ b/src/components/Button/CustomButton/CustomButton.styles.js
@@ -4,7 +4,6 @@ import { white, gray100, gray120, flexCenter } from '../../../core/GlobalStyle';
 export const Inner = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 1px;
 `;
 
 export const Container = styled.div`

--- a/src/components/Button/NewBaseButton/NewBaseButton.styles.js
+++ b/src/components/Button/NewBaseButton/NewBaseButton.styles.js
@@ -5,7 +5,6 @@ import { THEME_COLOR } from '../../../core/GlobalStyle/theme';
 export const Inner = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 1px;
 `;
 
 export const Container = styled.div`


### PR DESCRIPTION
버튼의 디자인 시각보정을 위해 margin-bottom을 삭제합니다.
![screenshot-6](https://user-images.githubusercontent.com/9426543/116639176-d9466f00-a9a2-11eb-884e-996ca2133b2f.png)

아래 -> margin-bottom 있을때
위 -> 이번 작업내요으로 margin-bottom 없을때

버튼 내부의 글자가 좀 더 가운데 정렬이 되도록 수정합니다.