### PR TITLE
PCWEB-7586 add: github package registry 배포

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remember-ui",
+  "name": "@dramancompany/remember-ui",
   "version": "2.1.1",
   "description": "Remember UI Components",
   "homepage": "https://github.com/dramancompany/remember-ui",
@@ -13,6 +13,13 @@
     "README.md",
     "index.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dramancompany/remember-ui.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "build": "rollup -c",
     "build:dev": "rollup -c rollup.config.dev.js -w",


### PR DESCRIPTION
## 작업 내용 (Content)

- 현재 npm 배포가 어려워 임시로 github packages를 통한 배포를 위해 package.json을 수정한 내용입니다
- remember-ui 배포를 위한 프로세스 및 환경 설정은 [wiki](https://dramancompany.atlassian.net/wiki/spaces/API/pages/27876393351/remember-ui+github+packages)를 참고해주세요
- 배포에 필요한 토큰은 요청 주시면 DM으로 전달 드리겠습니다

## 기타 사항 (Etc)

- npm 계정이 복구 되면 package.json은 롤백하고 그간 업데이트 되었던 버전이 npm으로 배포되어야 함
- 관리자 권한을 가지고 있으면 https://github.com/dramancompany/remember-ui/packages/1428298 에서 버전을 삭제할 수 있으므로, npm 계정 복구와 함께 버전을 삭제처리 할 것

## Merge 전 필요 작업 (Checklist before merge)

- X

## 희망 리뷰 완료 일 (Expected due date)

202X. X. X. Wed
