### PR TITLE
(#66) PCWEB-7747 github packages registry 기반 설치 방법 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@
 ## Reminders
 
 - [] TippyTheme must be loaded beforehand for proper use
+
+## 설치
+
+### personal access token 발급
+
+- github -> settings -> developer settings ->< personal access tokens에서 `read:packages` 권한이 있는 token 발급
+  <img width="858" alt="image" src="https://user-images.githubusercontent.com/41747333/171557101-866d2486-9e1c-4b95-8c91-786978b83ff4.png">
+
+- 프로젝트 내 .npmrc 파일 생성 후 아래 내용 작성
+
+```
+//npm.pkg.github.com/:_authToken=[발급받은 토큰]
+@dramancompany:registry=https://npm.pkg.github.com/
+```
+
+- install
+
+```
+$ yarn add @dramancompany/remember-ui
+```


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- npm -> github registry 변경에 따른 설치 방법을 readme에 추가했습니다
- 외부 링크 유출 방지를 위해 상세 내용은 PCWEB-7747에 포함된 링크를 확인해주세요

## 스크린샷 (Screenshot) 📷

- 

## 링크 (Links) 🔗

- [리멤버 ui 설치관련 readme 추가](https://dramancompany.atlassian.net/browse/PCWEB-7747)

## 기타 사항 (Etc) 🔖

- 

## 테스트 Checklist (Test Checklist) ✅

- 

## 희망 리뷰 완료 일 (Expected due date) ⏰

`Any time`
