### PR TITLE
PCWEB-7987 Popover의 size prop option 추가

### DIFF
--- a/docsSrc/components/Control/Popover/Popover.js
+++ b/docsSrc/components/Control/Popover/Popover.js
@@ -16,7 +16,7 @@ Popover.propTypes = {
   onPopoverOpenChange: t.func,
   customElement: t.object,
   content: t.object,
-  size: t.string,
+  size: t.oneOf(['small', 'large', 'auto']),
   trigger: t.oneOf(['click', 'focus', 'mouseenter']),
   className: t.string,
   distance: t.number,

--- a/src/components/Control/Popover/Popover.styles.js
+++ b/src/components/Control/Popover/Popover.styles.js
@@ -1,12 +1,17 @@
 import styled, { css } from 'styled-components';
 import Tippy from '@tippy.js/react';
 
+const SIZE_TO_WIDTH_MAP = {
+  small: '170px',
+  large: '236px',
+  auto: 'auto',
+};
+
 export const Popover = styled(Tippy)`
   border-radius: 10px !important;
   background-color: white !important;
   box-shadow: 0 0px 16px 0 rgba(0, 0, 0, 0.2) !important;
-  width: ${({ $size = 'small' }) =>
-    $size === 'small' ? '170px' : '236px'} !important;
+  width: ${({ $size = 'small' }) => SIZE_TO_WIDTH_MAP[$size]} !important;
 
   .tippy-content {
     padding: 0 !important;

--- a/src/components/Control/Popover/Popover.styles.js
+++ b/src/components/Control/Popover/Popover.styles.js
@@ -11,7 +11,7 @@ export const Popover = styled(Tippy)`
   border-radius: 10px !important;
   background-color: white !important;
   box-shadow: 0 0px 16px 0 rgba(0, 0, 0, 0.2) !important;
-  width: ${({ $size = 'small' }) => SIZE_TO_WIDTH_MAP[$size]} !important;
+  width: ${({ $size }) => SIZE_TO_WIDTH_MAP[$size]} !important;
 
   .tippy-content {
     padding: 0 !important;

--- a/src/components/Control/Popover/index.js
+++ b/src/components/Control/Popover/index.js
@@ -7,7 +7,7 @@ export const BasePopover = ({
   className = 'DcPopover',
   customElement,
   content,
-  size = 'small', // small or large
+  size = 'small', // 'small' | 'large' | 'auto'
   children,
   onOpen = () => {},
   distance = 10,
@@ -51,6 +51,7 @@ export const BasePopover = ({
       onMount={(inst) => setInstance(inst)}
       arrow={false}
       $size={size}
+      maxWidth="unset"
       onShow={() => {
         onPopoverOpenChange(true);
         onOpen();


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- Popover의 사이즈가 `small`(170px) | `large` (236px) 두가지 옵션 밖에 없어 디자인에 유연하게 대처하지 못함
  - `auto` 옵션 추가하여 컨텐츠에 따라 가변으로 사용할 수 있도록 수정

## 스크린샷 (Screenshot) 📷

- N/A

## 링크 (Links) 🔗

- [PCWEB-7987](https://dramancompany.atlassian.net/browse/PCWEB-7987)

## 기타 사항 (Etc) 🔖

- N/A

## 테스트 Checklist (Test Checklist) ✅

- N/A

## 희망 리뷰 완료 일 (Expected due date) ⏰

`ASAP`
