### PR TITLE
PCWEB-10247 DesignedModal에서 width를 Props로 받을 수 있도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dramancompany/remember-ui",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Remember UI Components",
   "homepage": "https://dramancompany.github.io/remember-ui/",
   "author": "DramanCompany",

--- a/src/components/Modal/DesignedModal/DesignedModal.styles.tsx
+++ b/src/components/Modal/DesignedModal/DesignedModal.styles.tsx
@@ -22,18 +22,13 @@ export const Container = styled(BaseModal)`
 
 export const Modal = styled.div<{
   isDraggable?: boolean;
-  width?: number | string;
-  height?: number | string;
+  $width?: number | string;
   mobileWidth?: number | string;
   mobileHeight?: number | string;
 }>`
   background-color: ${background100};
   border-radius: 10px;
-  width: ${({ width }) => width};
-  ${({ height }) =>
-    css`
-      height: ${height};
-    `};
+  width: ${({ $width }) => $width};
 
   ${({ isDraggable }) =>
     isDraggable &&

--- a/src/components/Modal/DesignedModal/DesignedModal.styles.tsx
+++ b/src/components/Modal/DesignedModal/DesignedModal.styles.tsx
@@ -22,12 +22,18 @@ export const Container = styled(BaseModal)`
 
 export const Modal = styled.div<{
   isDraggable?: boolean;
+  width?: number | string;
+  height?: number | string;
   mobileWidth?: number | string;
   mobileHeight?: number | string;
 }>`
   background-color: ${background100};
   border-radius: 10px;
-  width: 635px;
+  width: ${({ width }) => width};
+  ${({ height }) =>
+    css`
+      height: ${height};
+    `};
 
   ${({ isDraggable }) =>
     isDraggable &&

--- a/src/components/Modal/DesignedModal/index.tsx
+++ b/src/components/Modal/DesignedModal/index.tsx
@@ -36,7 +36,6 @@ export interface DesignedModalProps
   headerButton?: ReactNode;
   isLoading?: boolean;
   width?: string | number;
-  height?: string | number;
   mobileWidth?: string | number;
   mobileHeight?: string | number;
   bodyScrollLockTargetId?: string | null;
@@ -66,7 +65,6 @@ export const DesignedModal = ({
   dragOnStop = () => {},
   dragOnDrag = () => {},
   width = '635px',
-  height,
   mobileWidth = '90vw',
   mobileHeight,
   bodyScrollLockTargetId,
@@ -92,8 +90,7 @@ export const DesignedModal = ({
     >
       <Modal
         isDraggable={isDraggable}
-        width={width}
-        height={height}
+        $width={width}
         mobileWidth={mobileWidth}
         mobileHeight={mobileHeight}
       >

--- a/src/components/Modal/DesignedModal/index.tsx
+++ b/src/components/Modal/DesignedModal/index.tsx
@@ -35,6 +35,8 @@ export interface DesignedModalProps
   submitButtonDisabled?: boolean;
   headerButton?: ReactNode;
   isLoading?: boolean;
+  width?: string | number;
+  height?: string | number;
   mobileWidth?: string | number;
   mobileHeight?: string | number;
   bodyScrollLockTargetId?: string | null;
@@ -63,6 +65,8 @@ export const DesignedModal = ({
   dragOnStart = () => {},
   dragOnStop = () => {},
   dragOnDrag = () => {},
+  width = '635px',
+  height,
   mobileWidth = '90vw',
   mobileHeight,
   bodyScrollLockTargetId,
@@ -88,6 +92,8 @@ export const DesignedModal = ({
     >
       <Modal
         isDraggable={isDraggable}
+        width={width}
+        height={height}
         mobileWidth={mobileWidth}
         mobileHeight={mobileHeight}
       >


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- DesignedModal에서 width/height를 Props로 받을 수 있도록 수정
- 현재 width: 635px이 고정 값으로 들어가 있고 height도 받을 수 없도록 되어 있어서 모달의 크기를 변경할 수 없음
- Css로 하위 요소를 셀렉트 해서 스타일을 주려고 했지만 Portal로 인해 위게가 바뀌면서 오버라이드 불가.
- ref로 잡아서 인라인 스타일을 주는 방법도 있으나 이렇게 차력쇼를 하느니 remember-ui를 수정하는 것이 맞다고 판단함
- 관련 스레드 : https://dramancompany.slack.com/archives/C020CUB9P0Q/p1682053553774389

## 스크린샷 (Screenshot) 📷

- 필요하다면 스크린샷을 첨부해주세요.
- Attach a Screenshot if necessary.

## 링크 (Links) 🔗

- [JIRA 티켓 이름](https://dramancompany.atlassian.net/browse/PCWEB-)
- [개발 문서](https://dramancompany.atlassian.net/wiki/)
- [기획 문서](https://dramancompany.atlassian.net/wiki/)
- [디자인 문서](https://dramancompany.atlassian.net/wiki/)

## 기타 사항 (Etc) 🔖

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.
- Merge 전 필요한 작업이 있다면 적어주세요 (Checklist before merge)
- [ ] eg) Create XX table, Deploy app etc

## 테스트 Checklist (Test Checklist) ✅

- 꼭 테스트 해봐야하는 시나리오를 적어주세요
- [ ] eg) Test case

## 희망 리뷰 완료 일 (Expected due date) ⏰

`202X.X.X. Wed`
