### PR TITLE
PCWEB-11971 BaseModal Props 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,14 +74,14 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.4",
     "prettier": "^2.7.1",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "rollup-plugin-visualizer": "^5.8.1",
     "styled-components": "4.4.1",
     "typescript": "^4.6.4",
     "vite": "^3.0.9",
     "vite-plugin-dts": "^1.4.1",
-    "vite-tsconfig-paths": "^3.5.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "vite-tsconfig-paths": "^3.5.0"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dramancompany/remember-ui",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Remember UI Components",
   "homepage": "https://dramancompany.github.io/remember-ui/",
   "author": "DramanCompany",

--- a/src/components/Modal/BaseModal/BaseModal.stories.tsx
+++ b/src/components/Modal/BaseModal/BaseModal.stories.tsx
@@ -1,51 +1,57 @@
+import { StoryObj } from '@storybook/react';
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { NewBaseButton } from 'components/Buttons';
 
 import { BaseModal } from './index';
 
-const meta: ComponentMeta<typeof BaseModal> = {
+type Story = StoryObj<typeof BaseModal>;
+
+const meta = {
   title: 'Modal/BaseModal',
   component: BaseModal,
 };
 
-export const Variants: ComponentStory<typeof BaseModal> = () => {
-  const [isOpen, setIsOpen] = React.useState(true);
-  return (
-    <div style={{ width: 'fit-content' }}>
-      <NewBaseButton
-        theme="light"
-        size="large"
-        outline
-        onClick={() => setIsOpen(true)}
-      >
-        Open Modal
-      </NewBaseButton>
-      <BaseModal isOpen={isOpen} onClose={() => setIsOpen(false)}>
-        <div
-          style={{
-            boxShadow: '0px 0px 21px 0px rgba(143,143,143,0.4)',
-            backgroundColor: 'white',
-            height: '50vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexDirection: 'column',
-          }}
+export const Variants: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, setIsOpen] = React.useState(true);
+
+    return (
+      <div style={{ width: 'fit-content' }}>
+        <NewBaseButton
+          theme="light"
+          size="large"
+          outline
+          onClick={() => setIsOpen(true)}
         >
-          <span>Modal is Opened</span>
-          <NewBaseButton
-            theme="red"
-            size="large"
-            onClick={() => setIsOpen(false)}
+          Open Modal
+        </NewBaseButton>
+        <BaseModal isOpen={isOpen} onClose={() => setIsOpen(false)} {...args}>
+          <div
+            style={{
+              boxShadow: '0px 0px 21px 0px rgba(143,143,143,0.4)',
+              backgroundColor: 'white',
+              height: '50vh',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+            }}
           >
-            Close Modal
-          </NewBaseButton>
-        </div>
-      </BaseModal>
-    </div>
-  );
+            <span>Modal is Opened</span>
+            <NewBaseButton
+              theme="red"
+              size="large"
+              onClick={() => setIsOpen(false)}
+            >
+              Close Modal
+            </NewBaseButton>
+          </div>
+        </BaseModal>
+      </div>
+    );
+  },
 };
 
 export default meta;

--- a/src/components/Modal/BaseModal/index.tsx
+++ b/src/components/Modal/BaseModal/index.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from 'react';
-import Modal from 'react-modal';
 import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
+import { ReactNode } from 'react';
 import Draggable from 'react-draggable';
+import Modal from 'react-modal';
 
 import { enableBodyScrollLock } from '../../../utils/common';
 
@@ -9,7 +9,7 @@ import { Container } from './BaseModal.styles';
 
 Modal.setAppElement('body');
 
-export interface BaseModalProps {
+export interface BaseModalProps extends ReactModal.Props {
   isOpen: boolean;
   isDraggable?: boolean;
   isDragDisabled?: boolean;
@@ -42,6 +42,7 @@ export const BaseModal = ({
   dragOnStop = () => {},
   dragOnDrag = () => {},
   bodyScrollLockTarget = '',
+  ...props
 }: BaseModalProps) => {
   const dragBounds = isDraggable && isDragBounded ? '.dc-modal-overlay' : '';
   const dragCancelTarget = 'input, textarea, .not-draggable';
@@ -84,6 +85,7 @@ export const BaseModal = ({
        * modal의 경우 해당 액션이 필요하여 분기처리
        */
       shouldCloseOnEsc={allowKeyExit}
+      {...props}
     >
       {isDraggable && (
         <Draggable


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- [관련 스레드](https://dramancompany.slack.com/archives/C020CUB9P0Q/p1704877911233889)
- BaseModal을 사용하기 위해 react-modal의 props를 활용할 수 있도록 인터페이스를 확장했습니다. 
- 처음에는 HTMLDivElement를 확장하려고 했지만, 이 컴포넌트가 react-modal에 의존적이기 때문에 ReactModal.Props를 확장하는 것이 더 적합하다고 판단하여 위의 방향으로 수정했습니다.

## 스크린샷 (Screenshot) 📷

- 필요하다면 스크린샷을 첨부해주세요.
- Attach a Screenshot if necessary.

## 링크 (Links) 🔗

- [PCWEB-11971](https://dramancompany.atlassian.net/browse/PCWEB-11971)

## 기타 사항 (Etc) 🔖

- 버전 2.4.9로 올려도 되는지, 아니면 beta 버전으로 올려야하는지 컨펌 부탁드립니다.

## 테스트 Checklist (Test Checklist) ✅

- 꼭 테스트 해봐야하는 시나리오를 적어주세요
- [ ] eg) Test case

## 희망 리뷰 완료 일 (Expected due date) ⏰

`202X.X.X. Wed`


[PCWEB-11971]: https://dramancompany.atlassian.net/browse/PCWEB-11971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ