### PR TITLE
PCWEB-11978 ConfirmModal의 title props의 타입을 변경합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dramancompany/remember-ui",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Remember UI Components",
   "homepage": "https://dramancompany.github.io/remember-ui/",
   "author": "DramanCompany",

--- a/src/components/Modal/ConfirmModal/index.tsx
+++ b/src/components/Modal/ConfirmModal/index.tsx
@@ -51,7 +51,7 @@ export interface ConfirmModalProps
   > {
   icon?: IconType;
   type?: Type;
-  title?: string | JSX.Element;
+  title?: string | JSX.Element | ReactNode;
   message?: string;
   isOpen: boolean;
   showClose?: boolean;

--- a/src/components/Modal/ConfirmModal/index.tsx
+++ b/src/components/Modal/ConfirmModal/index.tsx
@@ -51,7 +51,7 @@ export interface ConfirmModalProps
   > {
   icon?: IconType;
   type?: Type;
-  title?: string;
+  title?: string | JSX.Element;
   message?: string;
   isOpen: boolean;
   showClose?: boolean;


### PR DESCRIPTION
## 작업 내용 (Content) 📝

ConfirmModal의 title 타입을 string에서 JSX.Element도 받을 수 있도록 변경합니다.

career-web의 ts migration시, string만이 아닌 JSX.Element도 넘어가도록 작성된 js 파일들이 있어서 해당 케이스에 대한 대응 작업입니다.

## 스크린샷 (Screenshot) 📷

- 필요하다면 스크린샷을 첨부해주세요.
- Attach a Screenshot if necessary.

## 링크 (Links) 🔗

- [PCWEB-11978](https://dramancompany.atlassian.net/browse/PCWEB-11978)
- [정리 문서](https://dramancompany.atlassian.net/wiki/spaces/~712020f16037adaeb24eec8532f77455c628f6/pages/28288155716/PCWEB-11943+career-web)


## 기타 사항 (Etc) 🔖

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.
- Merge 전 필요한 작업이 있다면 적어주세요 (Checklist before merge)
- [ ] eg) Create XX table, Deploy app etc

## 테스트 Checklist (Test Checklist) ✅

- 꼭 테스트 해봐야하는 시나리오를 적어주세요
- [ ] eg) Test case

## 희망 리뷰 완료 일 (Expected due date) ⏰

`202X.X.X. Wed`


[PCWEB-11978]: https://dramancompany.atlassian.net/browse/PCWEB-11978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ